### PR TITLE
Fix Xdebug >= 3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Ensure the data volume contains the requried directories:
 
 ```console
 docker-compose run --entrypoint install --rm app \
-  -d -o www-data -g www-data -m 750 /data/base /data/base/phpunit /data/behat /data/behat-faildump
+  -d -o www-data -g www-data -m 750 /data/base /data/xdebug /data/base/phpunit /data/behat /data/behat-faildump
 ```
 
 Install Moodle, over the CLI if you prefer:
@@ -50,11 +50,8 @@ docker-compose run --entrypoint php --rm app \
 
 ## Debugging
 
-To enable debugging support via Xdebug, ensure the following environment variables are set:
+To enable debugging support via Xdebug:
 
-```sh
-XDEBUG_CONFIG=remote_enable=On remote_autostart=On remote_connect_back=Off remote_host=docker.for.win.localhost remote_port=9000
-PHP_IDE_CONFIG=serverName=app
-```
-
-Then edit `docker-compose.yml` and replace the `image: ghcr.io/lukecarrier/moodle-php-fpm-7.2:latest`  line with `image: ghcr.io/lukecarrier/moodle-php-fpm-dev-7.2:latest`.
+1. Uncomment the appropriate environment variables in `.env`. You can check the Xdebug version used by each PHP version in the Makefile.
+2. Edit `docker-compose.yml` such that the `app` service uses the `moodle-php-fpm-$version-dev` image in place of `moodle-php-fpm-$version`.
+3. Configure your IDE to listen for Xdebug connections on port 9000, and set up path mapping for the Moodle directory to `/app` on the server.

--- a/docker-compose.php-7.0.yml
+++ b/docker-compose.php-7.0.yml
@@ -38,8 +38,8 @@ services:
         target: /data
         consistency: delegated
       - type: bind
-        source: ./_docker/data/app/profiler
-        target: /data/profiler
+        source: ./_docker/data/app/xdebug
+        target: /data/xdebug
 
   #cache:
   #  image: redis

--- a/docker-compose.php-7.2.yml
+++ b/docker-compose.php-7.2.yml
@@ -38,8 +38,8 @@ services:
         target: /data
         consistency: delegated
       - type: bind
-        source: ./_docker/data/app/profiler
-        target: /data/profiler
+        source: ./_docker/data/app/xdebug
+        target: /data/xdebug
 
   #cache:
   #  image: redis

--- a/docker-compose.php-7.4.yml
+++ b/docker-compose.php-7.4.yml
@@ -38,8 +38,8 @@ services:
         target: /data
         consistency: delegated
       - type: bind
-        source: ./_docker/data/app/profiler
-        target: /data/profiler
+        source: ./_docker/data/app/xdebug
+        target: /data/xdebug
 
   #cache:
   #  image: redis

--- a/docker-compose.php-8.0.yml
+++ b/docker-compose.php-8.0.yml
@@ -38,8 +38,8 @@ services:
         target: /data
         consistency: delegated
       - type: bind
-        source: ./_docker/data/app/profiler
-        target: /data/profiler
+        source: ./_docker/data/app/xdebug
+        target: /data/xdebug
 
   #cache:
   #  image: redis

--- a/docker-compose.php-8.2.yml
+++ b/docker-compose.php-8.2.yml
@@ -38,8 +38,8 @@ services:
         target: /data
         consistency: delegated
       - type: bind
-        source: ./_docker/data/app/profiler
-        target: /data/profiler
+        source: ./_docker/data/app/xdebug
+        target: /data/xdebug
 
   # cache:
   #   image: redis

--- a/images/php-fpm-dev/xdebug.ini
+++ b/images/php-fpm-dev/xdebug.ini
@@ -1,10 +1,3 @@
 [xdebug]
-; Remote debugging
-xdebug.remote_enable = On
-xdebug.remote_autostart = Off
-xdebug.remote_port = 9000
-
 ; Profiling
-xdebug.profiler_enable_trigger = On
-xdebug.profiler_output_dir = /data/profiler
 xdebug.profiler_output_name = cachegrind.out.%S.%s.%p.%u

--- a/sample.env
+++ b/sample.env
@@ -10,6 +10,10 @@
 # SQL Server
 #ACCEPT_EULA=Y
 
-# Xdebug
-#XDEBUG_CONFIG=remote_enable=On remote_autostart=On remote_connect_back=Off remote_host=docker.for.win.localhost remote_port=9000
-#PHP_IDE_CONFIG=serverName=app
+# Debugging and profiling
+# Xdebug 2.x
+PHP_IDE_CONFIG=serverName=app
+#XDEBUG_CONFIG=remote_autostart=On profiler_output_dir = /data/xdebug remote_connect_back=Off remote_host=host.containers.internal remote_port=9000
+# Xdebug 3.x
+XDEBUG_MODE=debug,develop,profile
+XDEBUG_CONFIG=output_dir=/data/xdebug start_with_request=trigger client_host=host.containers.internal client_port=9003


### PR DESCRIPTION
More recent Xdebug versions renamed a bunch of configuration options and changed the way triggers work, introducing the notion of modes.

Try to port the configuration over as faithfully as possible.